### PR TITLE
Added move api to list & dict

### DIFF
--- a/include/SimpleObjects/DefaultTypes.hpp
+++ b/include/SimpleObjects/DefaultTypes.hpp
@@ -80,11 +80,17 @@ using HashableObject = HashableObjectImpl<std::string>;
 
 // ========== Convenient types of List ==========
 
-using List = ListCat<VecType<Object>, std::string>;
+template<typename _ValType>
+using ListT = ListCat<VecType<_ValType>, std::string>;
+
+using List = ListT<Object>;
 
 // ========== Convenient types of Dict ==========
 
-using Dict = DictCat<MapType<HashableObject, Object>, std::string>;
+template<typename _KeyType, typename _Valtype>
+using DictT = DictCat<MapType<_KeyType, _Valtype>, std::string>;
+
+using Dict = DictT<HashableObject, Object>;
 
 // ========== Convenient types of base classes ==========
 

--- a/include/SimpleObjects/Dict.hpp
+++ b/include/SimpleObjects/Dict.hpp
@@ -258,6 +258,21 @@ public:
 		return {ToFrIt<false>(it), false};
 	}
 
+	virtual std::pair<iterator, bool> InsertOnly(
+		key_type&& key, mapped_type&& other) override
+	{
+		auto it = m_data.find(key);
+		if (it == m_data.end())
+		{
+			// insert
+			it = m_data.emplace(
+				std::forward<key_type>(key),
+				std::forward<mapped_type>(other)).first;
+			return {ToFrIt<false>(it), true};
+		}
+		return {ToFrIt<false>(it), false};
+	}
+
 	virtual std::pair<iterator, bool> InsertOrAssign(
 		const key_type& key, const mapped_type& other) override
 	{
@@ -272,6 +287,26 @@ public:
 		{
 			// assign
 			(*it).second = other;
+			return {ToFrIt<false>(it), false};
+		}
+	}
+
+	virtual std::pair<iterator, bool> InsertOrAssign(
+		key_type&& key, mapped_type&& other) override
+	{
+		auto it = m_data.find(key);
+		if (it == m_data.end())
+		{
+			// insert
+			it = m_data.emplace(
+				std::forward<key_type>(key),
+				std::forward<mapped_type>(other)).first;
+			return {ToFrIt<false>(it), true};
+		}
+		else
+		{
+			// assign
+			(*it).second = std::forward<mapped_type>(other);
 			return {ToFrIt<false>(it), false};
 		}
 	}

--- a/include/SimpleObjects/DictBaseObject.hpp
+++ b/include/SimpleObjects/DictBaseObject.hpp
@@ -136,8 +136,14 @@ public:
 	virtual std::pair<iterator, bool> InsertOnly(
 		const key_type& key, const mapped_type& other) = 0;
 
+	virtual std::pair<iterator, bool> InsertOnly(
+		key_type&& key, mapped_type&& other) = 0;
+
 	virtual std::pair<iterator, bool> InsertOrAssign(
 		const key_type& key, const mapped_type& other) = 0;
+
+	virtual std::pair<iterator, bool> InsertOrAssign(
+		key_type&& key, mapped_type&& other) = 0;
 
 	virtual void Remove(const key_type& key) = 0;
 

--- a/include/SimpleObjects/List.hpp
+++ b/include/SimpleObjects/List.hpp
@@ -293,6 +293,11 @@ public:
 		return ToRdIt<true>(it);
 	}
 
+	virtual void push_back(value_type&& ch) override
+	{
+		m_data.push_back(std::forward<value_type>(ch));
+	}
+
 	virtual void push_back(const value_type& ch) override
 	{
 		m_data.push_back(ch);

--- a/include/SimpleObjects/ListBaseObject.hpp
+++ b/include/SimpleObjects/ListBaseObject.hpp
@@ -164,6 +164,8 @@ public:
 
 	virtual const_iterator Contains(const_reference other) const = 0;
 
+	virtual void push_back(value_type&& ch) = 0;
+
 	virtual void push_back(const_reference ch) = 0;
 
 	virtual void pop_back() = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,9 +13,10 @@ include(TestCoverage.cmake)
 ################################################################################
 
 if(MSVC)
-	set(COMMON_OPTIONS /W3 /wd4996 /we4239 /we4002 /we4700 /we4305 /EHsc /MP)
+	set(COMMON_OPTIONS /W3 /wd4996 /we4239 /we4002 /we4700 /we4305 /EHsc /MP
+		/GR /Zc:__cplusplus)
 	set(DEBUG_OPTIONS /MTd /Od /Zi /DDEBUG)
-	set(RELEASE_OPTIONS /MT /Ox /Oi /Ob2 /fp:fast /GR-)# /DNDEBUG
+	set(RELEASE_OPTIONS /MT /Ox /Oi /Ob2 /fp:fast)# /DNDEBUG
 else()
 	set(COMMON_OPTIONS -pthread)
 	set(DEBUG_OPTIONS -O0 -g -DDEBUG)
@@ -29,11 +30,6 @@ if(MSVC)
 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /DEBUG")
 endif()
 
-add_compile_options(
-	"$<$<CONFIG:Debug>:${DEBUG_OPTIONS}>"
-	"$<$<CONFIG:Release>:${RELEASE_OPTIONS}>"
-)
-
 OPTION(SIMPLEOBJECTS_TEST_CXX_STANDARD
 	"C++ standard version used to build SimpleObjects test executable." 11)
 
@@ -44,18 +40,11 @@ OPTION(SIMPLEOBJECTS_TEST_CXX_STANDARD
 include(FetchContent)
 
 FetchContent_Declare(
-  git_googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.11.0
+	git_googletest
+	GIT_REPOSITORY https://github.com/google/googletest.git
+	GIT_TAG        release-1.11.0
 )
 FetchContent_MakeAvailable(git_googletest)
-
-# FetchContent_Declare(
-#   git_simpleutf
-#   GIT_REPOSITORY https://github.com/zhenghaven/SimpleUtf.git
-#   GIT_TAG        origin/main
-# )
-# FetchContent_MakeAvailable(git_simpleutf)
 
 ################################################################################
 # Adding testing executable
@@ -67,11 +56,10 @@ file(GLOB_RECURSE SOURCES ${SOURCES_DIR_PATH}/*.[ch]*)
 
 add_executable(SimpleObjects_test ${SOURCES})
 
-target_link_libraries(SimpleObjects_test SimpleObjects gtest) #SimpleUtf
-
-if(MSVC)
-	target_compile_options(SimpleObjects_test PUBLIC /GR /Zc:__cplusplus)
-endif()
+target_compile_options(SimpleObjects_test PUBLIC
+	"$<$<CONFIG:Debug>:${DEBUG_OPTIONS}>"
+	"$<$<CONFIG:Release>:${RELEASE_OPTIONS}>")
+target_link_libraries(SimpleObjects_test SimpleObjects gtest)
 
 add_test(NAME SimpleObjects_test
 	COMMAND SimpleObjects_test)

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -304,8 +304,24 @@ GTEST_TEST(TestDict, Insert)
 	};
 	EXPECT_NO_THROW(subTest1(););
 	EXPECT_TRUE(testDc.at(Int64(1)).AsString() == String("test val 1"));
-	//    Unsuccessful insert
+
+	EXPECT_THROW(testDc.at(Int64(2)), std::out_of_range);
 	auto subTest2 = [&]()
+	{
+		const auto tmpKey = HashableObject(Int64(2));
+		const auto tmpVal = Object(String("test val 2"));
+		auto res = testDc.InsertOnly(tmpKey, tmpVal);
+		EXPECT_TRUE(res.first->first.AsNumeric() == Int64(2));
+		EXPECT_TRUE(res.first->second.AsString() == String("test val 2"));
+		EXPECT_TRUE(&*res.first == &*testDc.find(Int64(2)));
+		EXPECT_TRUE(res.second == true);
+	};
+	EXPECT_NO_THROW(subTest2(););
+	EXPECT_TRUE(testDc.at(Int64(2)).AsString() == String("test val 2"));
+
+
+	//    Unsuccessful insert
+	auto subTest3 = [&]()
 	{
 		auto res = testDc.InsertOnly(Int64(1), String("test val 1_1"));
 		EXPECT_TRUE(res.first->first.AsNumeric() == Int64(1));
@@ -313,19 +329,58 @@ GTEST_TEST(TestDict, Insert)
 		EXPECT_TRUE(&*res.first == &*testDc.find(Int64(1)));
 		EXPECT_TRUE(res.second == false);
 	};
-	EXPECT_NO_THROW(subTest2(););
+	EXPECT_NO_THROW(subTest3(););
+	EXPECT_TRUE(testDc.at(Int64(1)).AsString() == String("test val 1"));
+
+	auto subTest4 = [&]()
+	{
+		const auto tmpKey = HashableObject(Int64(2));
+		const auto tmpVal = Object(String("test val 2_2"));
+		auto res = testDc.InsertOnly(tmpKey, tmpVal);
+		EXPECT_TRUE(res.first->first.AsNumeric() == Int64(2));
+		EXPECT_TRUE(res.first->second.AsString() == String("test val 2"));
+		EXPECT_TRUE(&*res.first == &*testDc.find(Int64(2)));
+		EXPECT_TRUE(res.second == false);
+	};
+	EXPECT_NO_THROW(subTest4(););
+	EXPECT_TRUE(testDc.at(Int64(2)).AsString() == String("test val 2"));
 
 	// InsertOrAssign
 	//    Insert
-	EXPECT_THROW(testDc.at(String("2")), std::out_of_range);
-	EXPECT_NO_THROW(
-		testDc.InsertOrAssign(String("2"), String("test val 2")));
-	EXPECT_TRUE(testDc.at(String("2")).AsString() == String("test val 2"));
+	{
+		EXPECT_THROW(testDc.at(String("2")), std::out_of_range);
+		EXPECT_NO_THROW(
+			auto res = testDc.InsertOrAssign(String("2"), String("test val 2"));
+			EXPECT_TRUE(res.second == true););
+		EXPECT_TRUE(testDc.at(String("2")).AsString() == String("test val 2"));
+	}
+
+	{
+		const auto tmpKey = HashableObject(String("3"));
+		const auto tmpVal = Object(String("test val 3"));
+		EXPECT_THROW(testDc.at(tmpKey), std::out_of_range);
+		EXPECT_NO_THROW(
+			auto res = testDc.InsertOrAssign(tmpKey, tmpVal);
+			EXPECT_TRUE(res.second == true););
+		EXPECT_TRUE(testDc.at(String("3")).AsString() == String("test val 3"));
+	}
 
 	//    Assign
-	EXPECT_NO_THROW(
-		testDc.InsertOrAssign(String("2"), String("test val 2_1")));
-	EXPECT_TRUE(testDc.at(String("2")).AsString() == String("test val 2_1"));
+	{
+		EXPECT_NO_THROW(
+			auto res = testDc.InsertOrAssign(String("2"), String("test val 2_1"));
+			EXPECT_TRUE(res.second == false););
+		EXPECT_TRUE(testDc.at(String("2")).AsString() == String("test val 2_1"));
+	}
+
+	{
+		const auto tmpKey = HashableObject(String("3"));
+		const auto tmpVal = Object(String("test val 3_1"));
+		EXPECT_NO_THROW(
+			auto res = testDc.InsertOrAssign(tmpKey, tmpVal);
+			EXPECT_TRUE(res.second == false););
+		EXPECT_TRUE(testDc.at(String("3")).AsString() == String("test val 3_1"));
+	}
 }
 
 GTEST_TEST(TestDict, Remove)

--- a/test/src/TestList.cpp
+++ b/test/src/TestList.cpp
@@ -340,8 +340,12 @@ GTEST_TEST(TestList, PushPopBack)
 	EXPECT_EQ(nkLs, List({String("Test String"),}));
 	EXPECT_NO_THROW(nkLs.push_back(Int64(12345)));
 	EXPECT_EQ(nkLs, List({String("Test String"),Int64(12345)}));
+	const auto tmpVal = Object(Double(123.0));
+	EXPECT_NO_THROW(nkLs.push_back(tmpVal));
+	EXPECT_EQ(nkLs, List({String("Test String"),Int64(12345), Double(123.0)}));
 
 	//popback
+	EXPECT_NO_THROW(nkLs.pop_back());
 	EXPECT_NO_THROW(nkLs.pop_back());
 	EXPECT_EQ(nkLs, List({String("Test String"),}));
 }


### PR DESCRIPTION
- Added move `push_back` API to `List`, and move `InsertOnly` and `InsertOrAssign` API to `Dict`
- Added `ListT` and `DictT` template alias type
- improved `CMakeLists.txt` for unit test code