### PR TITLE
refactored ListBaseObj & DictBaseObj API

### DIFF
--- a/include/SimpleObjects/BaseObject.hpp
+++ b/include/SimpleObjects/BaseObject.hpp
@@ -62,7 +62,7 @@ template<typename _ToStringType>
 class NumericBaseObject;
 template<typename _CharType, typename _ToStringType>
 class StringBaseObject;
-template<typename _ValType,  typename _ToStringType>
+template<typename _ValBaseType,  typename _ToStringType>
 class ListBaseObject;
 template<typename _KeyType,  typename _ValType,     typename _ToStringType>
 class DictBaseObject;
@@ -98,7 +98,7 @@ public: // Static members:
 
 	using StringBase  = StringBaseObject<char, ToStringType>;
 
-	using ListBase    = ListBaseObject<ObjectImpl<ToStringType>, ToStringType>;
+	using ListBase    = ListBaseObject<BaseObject<ToStringType>, ToStringType>;
 
 	using DictBase    = DictBaseObject<HashableObjectImpl<ToStringType>,
 		                               ObjectImpl<ToStringType>,

--- a/include/SimpleObjects/BaseObject.hpp
+++ b/include/SimpleObjects/BaseObject.hpp
@@ -79,11 +79,6 @@ template<typename _T>
 class HashableReferenceWrapper;
 
 template<typename _ToStringType>
-class HashableObjectImpl;
-template<typename _ToStringType>
-class ObjectImpl;
-
-template<typename _ToStringType>
 class BaseObject
 {
 public: // Static members:
@@ -100,8 +95,8 @@ public: // Static members:
 
 	using ListBase    = ListBaseObject<BaseObject<ToStringType>, ToStringType>;
 
-	using DictBase    = DictBaseObject<HashableObjectImpl<ToStringType>,
-		                               ObjectImpl<ToStringType>,
+	using DictBase    = DictBaseObject<HashableBaseObject<ToStringType>,
+		                               BaseObject<ToStringType>,
 		                               ToStringType>;
 
 	using StatDictBase = StaticDictBaseObject<HashableBaseObject<ToStringType>,

--- a/include/SimpleObjects/DefaultTypes.hpp
+++ b/include/SimpleObjects/DefaultTypes.hpp
@@ -100,7 +100,7 @@ using HashableBaseObj = HashableBaseObject<std::string>;
 using NumericBaseObj = NumericBaseObject<std::string>;
 using StringBaseObj = StringBaseObject<char, std::string>;
 using ListBaseObj = ListBaseObject<BaseObj, std::string>;
-using DictBaseObj = DictBaseObject<HashableObject, Object, std::string>;
+using DictBaseObj = DictBaseObject<HashableBaseObj, BaseObj, std::string>;
 using StaticDictBaseObj = StaticDictBaseObject<
 	HashableBaseObj,
 	BaseObj,

--- a/include/SimpleObjects/DefaultTypes.hpp
+++ b/include/SimpleObjects/DefaultTypes.hpp
@@ -99,7 +99,7 @@ using HashableBaseObj = HashableBaseObject<std::string>;
 
 using NumericBaseObj = NumericBaseObject<std::string>;
 using StringBaseObj = StringBaseObject<char, std::string>;
-using ListBaseObj = ListBaseObject<Object, std::string>;
+using ListBaseObj = ListBaseObject<BaseObj, std::string>;
 using DictBaseObj = DictBaseObject<HashableObject, Object, std::string>;
 using StaticDictBaseObj = StaticDictBaseObject<
 	HashableBaseObj,

--- a/include/SimpleObjects/Internal/IteratorTransform.hpp
+++ b/include/SimpleObjects/Internal/IteratorTransform.hpp
@@ -1,0 +1,68 @@
+// Copyright 2022 Haofan Zheng
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+namespace SimpleObjects
+#else
+namespace SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+#endif
+{
+namespace Internal
+{
+
+struct ItTransformDirect
+{
+	template<typename _RetType,
+		typename _ItType>
+	static _RetType GetRef(const _ItType& it)
+	{
+		return *it;
+	}
+
+	template<typename _RetType,
+		typename _ItType,
+		typename std::enable_if<
+			!std::is_pointer<_ItType>::value, bool>::type = true>
+	static _RetType GetPtr(const _ItType& it)
+	{
+		return it.operator->();
+	}
+
+	template<typename _RetType,
+		typename _ItType,
+		typename std::enable_if<
+			std::is_pointer<_ItType>::value, bool>::type = true>
+	static _RetType GetPtr(const _ItType& it)
+	{
+		return it;
+	}
+}; // struct ItTransformDirect
+
+template<size_t _Idx>
+struct ItTransformTupleGet
+{
+	template<typename _RetType,
+		typename _ItType>
+	static _RetType GetRef(const _ItType& it)
+	{
+		return std::get<_Idx>(*it);
+	}
+
+	template<typename _RetType,
+		typename _ItType>
+	static _RetType GetPtr(const _ItType& it)
+	{
+		return &std::get<_Idx>(*it);
+	}
+
+}; // struct ItTransformTupleGet
+
+} // Internal
+} // namespace SimpleObjects

--- a/include/SimpleObjects/Iterator.hpp
+++ b/include/SimpleObjects/Iterator.hpp
@@ -9,6 +9,9 @@
 
 #include "IteratorIf.hpp"
 #include "IteratorStdCpp.hpp"
+#include "IteratorZip.hpp"
+
+#include "Internal/IteratorTransform.hpp"
 
 #ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
 namespace SimpleObjects
@@ -619,7 +622,8 @@ template<typename _OriItType,
 	typename _ValType = typename std::iterator_traits<_OriItType>::value_type>
 inline InIterator<_ValType> ToInIt(_OriItType it)
 {
-	using ItWrap = CppStdInIteratorWrap<_OriItType, _ValType, true>;
+	using ItWrap = CppStdInIteratorWrap<
+		_OriItType, _ValType, true, Internal::ItTransformDirect>;
 	return InIterator<_ValType>(ItWrap::Build(it));
 }
 
@@ -628,7 +632,8 @@ template<bool _IsConst,
 	typename _ValType = typename std::iterator_traits<_OriItType>::value_type>
 inline FrIterator<_ValType, _IsConst> ToFrIt(_OriItType it)
 {
-	using ItWrap = CppStdFwIteratorWrap<_OriItType, _ValType, _IsConst>;
+	using ItWrap = CppStdFwIteratorWrap<
+		_OriItType, _ValType, _IsConst, Internal::ItTransformDirect>;
 	return FrIterator<_ValType, _IsConst>(ItWrap::Build(it));
 }
 
@@ -637,7 +642,8 @@ template<bool _IsConst,
 	typename _ValType = typename std::iterator_traits<_OriItType>::value_type>
 inline BiIterator<_ValType, _IsConst> ToBiIt(_OriItType it)
 {
-	using ItWrap = CppStdBiIteratorWrap<_OriItType, _ValType, _IsConst>;
+	using ItWrap = CppStdBiIteratorWrap<
+		_OriItType, _ValType, _IsConst, Internal::ItTransformDirect>;
 	return BiIterator<_ValType, _IsConst>(ItWrap::Build(it));
 }
 
@@ -646,8 +652,21 @@ template<bool _IsConst,
 	typename _ValType = typename std::iterator_traits<_OriItType>::value_type>
 inline RdIterator<_ValType, _IsConst> ToRdIt(_OriItType it)
 {
-	using ItWrap = CppStdRdIteratorWrap<_OriItType, _ValType, _IsConst>;
+	using ItWrap = CppStdRdIteratorWrap<
+		_OriItType, _ValType, _IsConst, Internal::ItTransformDirect>;
 	return RdIterator<_ValType, _IsConst>(ItWrap::Build(it));
+}
+
+template<bool _IsConst, typename ..._ItTypes>
+inline FrIterator<std::tuple<_ItTypes...>, _IsConst> FwItZip(_ItTypes... its)
+{
+	using ValType = std::tuple<_ItTypes...>;
+	using ItWrap = FwItZipper<_IsConst, _ItTypes...>;
+
+	// TODO: make_unique
+	auto ptr = std::unique_ptr<ItWrap>(new ItWrap(its...));
+
+	return FrIterator<ValType, _IsConst>(std::move(ptr));
 }
 
 }//namespace SimpleObjects

--- a/include/SimpleObjects/IteratorStdCpp.hpp
+++ b/include/SimpleObjects/IteratorStdCpp.hpp
@@ -95,14 +95,19 @@ public:
 	_OriItType m_it;
 }; // class CppStdOutIteratorWrap
 
-template<typename _OriItType, typename _TargetType, bool _IsConst>
+template<
+	typename _OriItType,
+	typename _TargetType,
+	bool _IsConst,
+	typename _Transform>
 class CppStdInIteratorWrap : public InputIteratorIf<_TargetType, _IsConst>
 {
 public: // Static members:
 	using _BaseIf = InputIteratorIf<_TargetType, _IsConst>;
 	using _BaseIfPtr = std::unique_ptr<_BaseIf>;
 
-	using Self = CppStdInIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using Self = CppStdInIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	typedef typename _BaseIf::difference_type         difference_type;
 	typedef typename _BaseIf::value_type              value_type;
@@ -149,12 +154,12 @@ public:
 
 	virtual reference GetRef() override
 	{
-		return *m_it;
+		return _Transform::template GetRef<reference>(m_it);
 	}
 
 	virtual pointer GetPtr() const override
 	{
-		return GetPtrImpl(m_it);
+		return _Transform::template GetPtr<pointer>(m_it);
 	}
 
 	virtual bool IsEqual(const _BaseIf& rhs) const override
@@ -173,35 +178,22 @@ public:
 
 	_OriItType m_it;
 
-protected:
-
-	template<
-		typename _ItType,
-		typename std::enable_if<std::is_class<_ItType>::value, bool>::type = true>
-	static pointer GetPtrImpl(const _ItType& it)
-	{
-		return it.operator->();
-	}
-
-	template<
-		typename _ItType,
-		typename std::enable_if<std::is_pointer<_ItType>::value, bool>::type = true>
-	static pointer GetPtrImpl(const _ItType& it)
-	{
-		return it;
-	}
-
 }; // class CppStdInIteratorWrap
 
 
-template<typename _OriItType, typename _TargetType, bool _IsConst>
+template<
+	typename _OriItType,
+	typename _TargetType,
+	bool _IsConst,
+	typename _Transform>
 class CppStdFwIteratorWrap :
 	public ForwardIteratorIf<_TargetType, _IsConst>,
-	public CppStdInIteratorWrap<_OriItType, _TargetType, _IsConst>
+	public CppStdInIteratorWrap<_OriItType, _TargetType, _IsConst, _Transform>
 {
 public: // Static members:
 
-	using Self = CppStdFwIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using Self = CppStdFwIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	using _BaseInIf = InputIteratorIf<_TargetType, _IsConst>;
 	using _BaseInIfPtr = std::unique_ptr<_BaseInIf>;
@@ -209,7 +201,8 @@ public: // Static members:
 	using _BaseIf = ForwardIteratorIf<_TargetType, _IsConst>;
 	using _BaseIfPtr = std::unique_ptr<_BaseIf>;
 
-	using _Base = CppStdInIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using _Base = CppStdInIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	typedef typename _BaseIf::difference_type         difference_type;
 	typedef typename _BaseIf::value_type              value_type;
@@ -277,10 +270,14 @@ private:
 }; // class CppStdFwIteratorWrap
 
 
-template<typename _OriItType, typename _TargetType, bool _IsConst>
+template<
+	typename _OriItType,
+	typename _TargetType,
+	bool _IsConst,
+	typename _Transform>
 class CppStdBiIteratorWrap :
 	public BidirectionalIteratorIf<_TargetType, _IsConst>,
-	public CppStdFwIteratorWrap<_OriItType, _TargetType, _IsConst>
+	public CppStdFwIteratorWrap<_OriItType, _TargetType, _IsConst, _Transform>
 {
 public: // Static members:
 
@@ -293,7 +290,8 @@ public: // Static members:
 	using _BaseIf = BidirectionalIteratorIf<_TargetType, _IsConst>;
 	using _BaseIfPtr = std::unique_ptr<_BaseIf>;
 
-	using _Base = CppStdFwIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using _Base = CppStdFwIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	typedef typename _BaseIf::difference_type         difference_type;
 	typedef typename _BaseIf::value_type              value_type;
@@ -361,13 +359,18 @@ private:
 
 }; // class CppStdBiIteratorWrap
 
-template<typename _OriItType, typename _TargetType, bool _IsConst>
+template<
+	typename _OriItType,
+	typename _TargetType,
+	bool _IsConst,
+	typename _Transform>
 class CppStdRdIteratorWrap :
 	public RandomAccessIteratorIf<_TargetType, _IsConst>,
-	public CppStdBiIteratorWrap<_OriItType, _TargetType, _IsConst>
+	public CppStdBiIteratorWrap<_OriItType, _TargetType, _IsConst, _Transform>
 {
 public: // Static members:
-	using Self = CppStdRdIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using Self = CppStdRdIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	using _BaseInIf = InputIteratorIf<_TargetType, _IsConst>;
 	using _BaseInIfPtr = std::unique_ptr<_BaseInIf>;
@@ -381,7 +384,8 @@ public: // Static members:
 	using _BaseIf = RandomAccessIteratorIf<_TargetType, _IsConst>;
 	using _BaseIfPtr = std::unique_ptr<_BaseIf>;
 
-	using _Base = CppStdBiIteratorWrap<_OriItType, _TargetType, _IsConst>;
+	using _Base = CppStdBiIteratorWrap<
+		_OriItType, _TargetType, _IsConst, _Transform>;
 
 	typedef typename _BaseIf::difference_type         difference_type;
 	typedef typename _BaseIf::value_type              value_type;

--- a/include/SimpleObjects/IteratorZip.hpp
+++ b/include/SimpleObjects/IteratorZip.hpp
@@ -1,0 +1,141 @@
+// Copyright 2022 Haofan Zheng
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <tuple>
+
+#include "IteratorIf.hpp"
+#include "Utils.hpp"
+
+#ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+namespace SimpleObjects
+#else
+namespace SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+#endif
+{
+
+namespace Internal
+{
+
+struct TupleItemIncrement
+{
+	template<typename _ItemType>
+	void operator()(_ItemType& i)
+	{
+		++i;
+	}
+}; // struct TupleItemIncrement
+
+struct IsIteratorTupleEqual
+{
+	IsIteratorTupleEqual() :
+		m_isEqual(false)
+	{}
+
+	/**
+	 * @brief The result will be true as long as there is at least one
+	 *        called pair is equal
+	 *
+	 */
+	template<typename _ItemType1, typename _ItemType2>
+	void operator()(const _ItemType1& a, const _ItemType2& b)
+	{
+		m_isEqual = m_isEqual || (a == b);
+	}
+
+	bool m_isEqual;
+}; // struct IsIteratorTupleEqual
+
+} // namespace Internal
+
+/**
+ * @brief An iterator zipper (that provides forward iterator capabilities) for
+ *        forward iterators
+ *
+ * @tparam _Iterators The list of types of the given iterators
+ */
+template<bool _IsConst, typename ..._Iterators>
+class FwItZipper :
+	public ForwardIteratorIf<std::tuple<_Iterators...>, _IsConst>
+{
+public: // Static members:
+
+	using TupleType = std::tuple<_Iterators...>;
+
+	using Self = FwItZipper<_IsConst, _Iterators...>;
+
+	using BaseInIf = InputIteratorIf<TupleType, _IsConst>;
+	using BaseInIfPtr = std::unique_ptr<BaseInIf>;
+
+	using BaseIf = ForwardIteratorIf<TupleType, _IsConst>;
+	using BaseIfPtr = std::unique_ptr<BaseIf>;
+
+	typedef typename BaseIf::difference_type         difference_type;
+	typedef typename BaseIf::value_type              value_type;
+	typedef typename BaseIf::pointer                 pointer;
+	typedef typename BaseIf::const_pointer           const_pointer;
+	typedef typename BaseIf::reference               reference;
+	typedef typename BaseIf::iterator_category       iterator_category;
+
+public:
+
+	template<typename... T>
+	explicit FwItZipper(T&&... args) :
+		m_its(std::forward<T>(args)...)
+	{}
+
+	FwItZipper(const Self& other):
+		m_its(other.m_its)
+	{}
+
+	FwItZipper(Self&& other):
+		m_its(std::forward<TupleType>(other.m_its))
+	{}
+
+	virtual void Increment() override
+	{
+		Internal::TupleOperation::UnaOp(m_its, Internal::TupleItemIncrement());
+	}
+
+	virtual reference GetRef() override
+	{
+		return m_its;
+	}
+
+	virtual pointer GetPtr() const override
+	{
+		const TupleType* ptr = &m_its;
+		return const_cast<pointer>(ptr);
+	}
+
+	virtual bool IsEqual(const BaseInIf& rhs) const override
+	{
+		const auto& otherWrap = Internal::DownCast<Self>(rhs);
+
+		Internal::IsIteratorTupleEqual res;
+		Internal::TupleOperation::BinOp(m_its, otherWrap.m_its, res);
+
+		return res.m_isEqual;
+	}
+
+	virtual BaseInIfPtr Copy(const BaseInIf&) const override
+	{ return CopyImpl(); }
+	virtual BaseIfPtr Copy(const BaseIf&) const override
+	{ return CopyImpl(); }
+
+private:
+
+	BaseIfPtr CopyImpl() const
+	{
+		// TODO: make_unique
+		return BaseIfPtr(new FwItZipper(*this));
+	}
+
+	TupleType m_its;
+
+}; // class FwItZipper
+
+}//namespace SimpleObjects

--- a/test/src/TestIterator.cpp
+++ b/test/src/TestIterator.cpp
@@ -28,35 +28,45 @@ GTEST_TEST(TestIterator, CountTestFile)
 GTEST_TEST(TestIterator, ItTraits)
 {
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, false>::difference_type,
+		typename CppStdRdIteratorWrap<
+			std::string::iterator, char, false, Internal::ItTransformDirect>::difference_type,
 		std::ptrdiff_t>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, false>::value_type,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, false, Internal::ItTransformDirect>::value_type,
 		char>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, false>::pointer,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, false, Internal::ItTransformDirect>::pointer,
 		char*>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, false>::reference,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, false, Internal::ItTransformDirect>::reference,
 		char&>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, false>::iterator_category,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, false, Internal::ItTransformDirect>::iterator_category,
 		std::random_access_iterator_tag>::value, "ItTraits test failed.");
 
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, true>::difference_type,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, true, Internal::ItTransformDirect>::difference_type,
 		std::ptrdiff_t>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, true>::value_type,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, true, Internal::ItTransformDirect>::value_type,
 		char>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, true>::pointer,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, true, Internal::ItTransformDirect>::pointer,
 		const char*>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, true>::reference,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, true, Internal::ItTransformDirect>::reference,
 		const char&>::value, "ItTraits test failed.");
 	static_assert(std::is_same<
-		typename CppStdRdIteratorWrap<std::string::iterator, char, true>::iterator_category,
+		typename CppStdRdIteratorWrap<
+		std::string::iterator, char, true, Internal::ItTransformDirect>::iterator_category,
 		std::random_access_iterator_tag>::value, "ItTraits test failed.");
 }
 


### PR DESCRIPTION
- Instead of handling a specific `value_type` for the list, now we are able to handle the most basic interface (i.e., `BaseObject`) on `ListBaseObj` API.
- Added iterator zipper to zip multiple iterators
- Instead of handling a specific `key_type` and `mapped_type` for the dictionary, now we are able to handle the most basic interface (i.e., `HashableBaseObject` for key and `BaseObject` for value) on `DictBaseObj` API.