### PR TITLE
Upgraded unit test code warning level

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,11 +28,22 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSIMPLEOBJECTS_TEST=ON -DSIMPLEOBJECTS_TEST_CXX_STANDARD=${{ matrix.std }} -DSIMPLEOBJECTS_TEST_LCOV=OFF
+      run: >
+        cmake
+        -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DSIMPLEOBJECTS_TEST=ON
+        -DSIMPLEOBJECTS_TEST_CXX_STANDARD=${{ matrix.std }}
+        -DSIMPLEOBJECTS_TEST_LCOV=OFF
+
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: >
+        cmake
+        --build ${{github.workspace}}/build
+        --config ${{env.BUILD_TYPE}}
+
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/include/SimpleObjects/BaseObject.hpp
+++ b/include/SimpleObjects/BaseObject.hpp
@@ -169,42 +169,42 @@ public:
 
 	virtual void Set(Self&& other) = 0;
 
-	virtual void Set(bool val)
+	virtual void Set(bool)
 	{
 		throw TypeError(this->GetCategoryName(), "bool");
 	}
 
-	virtual void Set(uint8_t val)
+	virtual void Set(uint8_t)
 	{
 		throw TypeError(this->GetCategoryName(), "uint8_t");
 	}
 
-	virtual void Set(int8_t val)
+	virtual void Set(int8_t)
 	{
 		throw TypeError(this->GetCategoryName(), "int8_t");
 	}
 
-	virtual void Set(uint32_t val)
+	virtual void Set(uint32_t)
 	{
 		throw TypeError(this->GetCategoryName(), "uint32_t");
 	}
 
-	virtual void Set(int32_t val)
+	virtual void Set(int32_t)
 	{
 		throw TypeError(this->GetCategoryName(), "int32_t");
 	}
 
-	virtual void Set(uint64_t val)
+	virtual void Set(uint64_t)
 	{
 		throw TypeError(this->GetCategoryName(), "uint64_t");
 	}
 
-	virtual void Set(int64_t val)
+	virtual void Set(int64_t)
 	{
 		throw TypeError(this->GetCategoryName(), "int64_t");
 	}
 
-	virtual void Set(double val)
+	virtual void Set(double)
 	{
 		throw TypeError(this->GetCategoryName(), "double");
 	}

--- a/include/SimpleObjects/Internal/rj_dtoa.hpp
+++ b/include/SimpleObjects/Internal/rj_dtoa.hpp
@@ -198,18 +198,18 @@ inline void Prettify(ContainerType& buf, int k, int16_t maxDecimal) {
 	static constexpr size_t maxSigWidth = 21;
 
 	const int signAdjust = (buf.size() > 0 && buf[0] == '-') ? -1 : 0;
-	const size_t sigLen = buf.size() + signAdjust;
-	const int kk = static_cast<int>(buf.size()) + signAdjust + k;  // 10^(kk-1) <= v < 10^kk
+	const int sigLen = static_cast<int>(buf.size()) + signAdjust;
+	const int kk     = static_cast<int>(buf.size()) + signAdjust + k;  // 10^(kk-1) <= v < 10^kk
 	const int maxDecimalPlaces = maxDecimal;
 
-	if (0 <= k && kk <= maxSigWidth) {
+	if (0 <= k && ((kk < 0) || (static_cast<size_t>(kk) <= maxSigWidth))) {
 		// 1234e7 -> 12340000000
 		buf.insert(buf.end(), k, '0');
 		buf.push_back('.');
 		buf.push_back('0');
 		return;
 	}
-	else if (0 < kk && kk <= maxSigWidth) {
+	else if (0 < kk && static_cast<size_t>(kk) <= maxSigWidth) {
 		// implies
 		//     (0 <= k) != true
 		//     0 > k

--- a/include/SimpleObjects/IteratorIf.hpp
+++ b/include/SimpleObjects/IteratorIf.hpp
@@ -162,6 +162,7 @@ public:
 
 	virtual ~ForwardIteratorIf() = default;
 
+	using _Base::Copy;
 	virtual SelfPtr Copy(const Self& /*unused*/) const = 0;
 
 }; //class ForwardIteratorIf
@@ -191,6 +192,7 @@ public:
 
 	virtual void Decrement() = 0;
 
+	using _Base::Copy;
 	virtual SelfPtr Copy(const Self& /*unused*/) const = 0;
 
 }; //class BidirectionalIteratorIf
@@ -222,6 +224,7 @@ public:
 
 	virtual difference_type Diff(const Self& other) const = 0;
 
+	using _Base::Copy;
 	virtual SelfPtr Copy(const Self& /*unused*/) const = 0;
 
 }; //class RandomAccessIteratorIf

--- a/include/SimpleObjects/Null.hpp
+++ b/include/SimpleObjects/Null.hpp
@@ -113,12 +113,12 @@ public:
 			>::AsChild(*this, "Null", this->GetCategoryName());
 	}
 
-	virtual bool operator==(const Self& rhs) const
+	virtual bool operator==(const Self&) const
 	{
 		return true;
 	}
 
-	virtual bool operator!=(const Self& rhs) const
+	virtual bool operator!=(const Self&) const
 	{
 		return false;
 	}

--- a/include/SimpleObjects/Numeric.hpp
+++ b/include/SimpleObjects/Numeric.hpp
@@ -279,21 +279,15 @@ public:
 	template<typename _RhsValType, typename _RhsStringType>
 	bool operator==(const Numeric<_RhsValType, _RhsStringType>& rhs) const
 	{
-		return (
-			Internal::
-				BoolToInt<InternalType, _RhsValType>::Convert(m_data) ==
-			Internal::
-				BoolToInt<_RhsValType, InternalType>::Convert(rhs.m_data));
+		using namespace Internal;
+		return (Compare<InternalType, _RhsValType>::Equal(
+			(m_data), (rhs.m_data)));
 	}
 
 	template<typename _RhsValType, typename _RhsStringType>
 	bool operator!=(const Numeric<_RhsValType, _RhsStringType>& rhs) const
 	{
-		return (
-			Internal::
-				BoolToInt<InternalType, _RhsValType>::Convert(m_data) !=
-			Internal::
-				BoolToInt<_RhsValType, InternalType>::Convert(rhs.m_data));
+		return !(this->operator==(rhs));
 	}
 
 	template<typename _RhsValType, typename _RhsStringType>

--- a/include/SimpleObjects/PrimitiveCmp.hpp
+++ b/include/SimpleObjects/PrimitiveCmp.hpp
@@ -52,6 +52,10 @@ template<>
 struct cmp_impl<true, true>
 {
 	template<typename T, typename U>
+	static constexpr bool cmp_equal(T t, U u) noexcept
+	{ return t == u; }
+
+	template<typename T, typename U>
 	static constexpr bool cmp_less(T t, U u) noexcept
 	{ return t < u; }
 }; // struct cmp_impl
@@ -60,6 +64,10 @@ template<>
 struct cmp_impl<false, false>
 {
 	template<typename T, typename U>
+	static constexpr bool cmp_equal(T t, U u) noexcept
+	{ return t == u; }
+
+	template<typename T, typename U>
 	static constexpr bool cmp_less(T t, U u) noexcept
 	{ return t < u; }
 }; // struct cmp_impl
@@ -67,6 +75,13 @@ struct cmp_impl<false, false>
 template<>
 struct cmp_impl<true, false>
 {
+	template<typename T, typename U>
+	static constexpr bool cmp_equal(T t, U u) noexcept
+	{
+		using UT = typename std::make_unsigned<T>::type;
+		return (t < 0 ? false : UT(t) == u);
+	}
+
 	template<typename T, typename U>
 	static constexpr bool cmp_less(T t, U u) noexcept
 	{
@@ -78,6 +93,13 @@ struct cmp_impl<true, false>
 template<>
 struct cmp_impl<false, true>
 {
+	template<typename T, typename U>
+	static constexpr bool cmp_equal(T t, U u) noexcept
+	{
+		using UU = typename std::make_unsigned<U>::type;
+		return (u < 0 ? false : t == UU(u));
+	}
+
 	template<typename T, typename U>
 	static constexpr bool cmp_less(T t, U u) noexcept
 	{
@@ -99,6 +121,16 @@ struct cmp_impl<false, true>
  * @return
  */
 template<typename T, typename U>
+inline constexpr bool cmp_equal(T t, U u) noexcept
+{
+	static_assert(IsPrimitiveType<T>::value, "Expecting a primitive type");
+	static_assert(IsPrimitiveType<U>::value, "Expecting a primitive type");
+
+	return cmp_impl<std::is_signed<T>::value,
+		std::is_signed<U>::value>::cmp_equal(t, u);
+}
+
+template<typename T, typename U>
 inline constexpr bool cmp_less(T t, U u) noexcept
 {
 	static_assert(IsPrimitiveType<T>::value, "Expecting a primitive type");
@@ -108,18 +140,6 @@ inline constexpr bool cmp_less(T t, U u) noexcept
 		std::is_signed<U>::value>::cmp_less(t, u);
 }
 
-/**
- * @brief A comparison that is safe against lossy integer conversion.
- *        source: https://en.cppreference.com/w/cpp/utility/intcmp
- *        Even though this is provided in C++20, we still need to support
- *        older versions
- *
- * @tparam T
- * @tparam U
- * @param t
- * @param u
- * @return
- */
 template<typename T, typename U>
 inline constexpr bool cmp_greater(T t, U u) noexcept
 {
@@ -143,6 +163,11 @@ struct CompareImpl;
 template<typename _LhsType, typename _RhsType>
 struct CompareImpl<true, _LhsType, _RhsType>
 {
+	static constexpr bool Equal(_LhsType lhs, _RhsType rhs)
+	{
+		return cmp_equal(lhs, rhs);
+	}
+
 	static constexpr bool Less(_LhsType lhs, _RhsType rhs)
 	{
 		return cmp_less(lhs, rhs);
@@ -157,6 +182,11 @@ struct CompareImpl<true, _LhsType, _RhsType>
 template<typename _LhsType, typename _RhsType>
 struct CompareImpl<false, _LhsType, _RhsType>
 {
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CustomCompare<_LhsType, _RhsType>::Equal(lhs, rhs);
+	}
+
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CustomCompare<_LhsType, _RhsType>::Less(lhs, rhs);
@@ -179,6 +209,12 @@ struct CompareFilterDouble
 		IsPrimitiveType<_LhsType>::value &&
 		IsPrimitiveType<_RhsType>::value);
 
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CompareImpl<
+			sk_isBothPrimitive, _LhsType, _RhsType>::Equal(lhs, rhs);
+	}
+
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CompareImpl<
@@ -195,6 +231,8 @@ struct CompareFilterDouble
 template<typename _RhsType>
 struct CompareFilterDouble<double, _RhsType>
 {
+	static constexpr bool Equal(double lhs, const _RhsType& rhs)
+	{ return lhs == rhs; }
 	static constexpr bool Less(double lhs, const _RhsType& rhs)
 	{ return lhs < rhs; }
 	static constexpr bool Greater(double lhs, const _RhsType& rhs)
@@ -204,6 +242,8 @@ struct CompareFilterDouble<double, _RhsType>
 template<typename _LhsType>
 struct CompareFilterDouble<_LhsType, double>
 {
+	static constexpr bool Equal(const _LhsType& lhs, double rhs)
+	{ return lhs == rhs; }
 	static constexpr bool Less(const _LhsType& lhs, double rhs)
 	{ return lhs < rhs; }
 	static constexpr bool Greater(const _LhsType& lhs, double rhs)
@@ -216,6 +256,10 @@ struct CompareFilterFloat;
 template<typename _LhsType, typename _RhsType>
 struct CompareFilterFloat
 { // next to filter double
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CompareFilterDouble<_LhsType, _RhsType>::Equal(lhs, rhs);
+	}
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CompareFilterDouble<_LhsType, _RhsType>::Less(lhs, rhs);
@@ -229,6 +273,8 @@ struct CompareFilterFloat
 template<typename _RhsType>
 struct CompareFilterFloat<float, _RhsType>
 {
+	static constexpr bool Equal(float lhs, const _RhsType& rhs)
+	{ return lhs == rhs; }
 	static constexpr bool Less(float lhs, const _RhsType& rhs)
 	{ return lhs < rhs; }
 	static constexpr bool Greater(float lhs, const _RhsType& rhs)
@@ -238,6 +284,8 @@ struct CompareFilterFloat<float, _RhsType>
 template<typename _LhsType>
 struct CompareFilterFloat<_LhsType, float>
 {
+	static constexpr bool Equal(const _LhsType& lhs, float rhs)
+	{ return lhs == rhs; }
 	static constexpr bool Less(const _LhsType& lhs, float rhs)
 	{ return lhs < rhs; }
 	static constexpr bool Greater(const _LhsType& lhs, float rhs)
@@ -250,6 +298,10 @@ struct CompareFilterBool;
 template<typename _LhsType, typename _RhsType>
 struct CompareFilterBool
 { // next to filter float
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CompareFilterFloat<_LhsType, _RhsType>::Equal(lhs, rhs);
+	}
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CompareFilterFloat<_LhsType, _RhsType>::Less(lhs, rhs);
@@ -263,6 +315,8 @@ struct CompareFilterBool
 template<typename _RhsType>
 struct CompareFilterBool<bool, _RhsType>
 {
+	static constexpr bool Equal(bool lhs, const _RhsType& rhs)
+	{ return static_cast<_RhsType>(lhs) == rhs; }
 	static constexpr bool Less(bool lhs, const _RhsType& rhs)
 	{ return static_cast<_RhsType>(lhs) < rhs; }
 	static constexpr bool Greater(bool lhs, const _RhsType& rhs)
@@ -272,6 +326,8 @@ struct CompareFilterBool<bool, _RhsType>
 template<typename _LhsType>
 struct CompareFilterBool<_LhsType, bool>
 {
+	static constexpr bool Equal(const _LhsType& lhs, bool rhs)
+	{ return lhs == static_cast<_LhsType>(rhs); }
 	static constexpr bool Less(const _LhsType& lhs, bool rhs)
 	{ return lhs < static_cast<_LhsType>(rhs); }
 	static constexpr bool Greater(const _LhsType& lhs, bool rhs)
@@ -284,6 +340,10 @@ struct CompareFilterSame;
 template<typename _LhsType, typename _RhsType>
 struct CompareFilterSame
 { // next to filter bool
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CompareFilterBool<_LhsType, _RhsType>::Equal(lhs, rhs);
+	}
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CompareFilterBool<_LhsType, _RhsType>::Less(lhs, rhs);
@@ -297,6 +357,8 @@ struct CompareFilterSame
 template<typename _Type>
 struct CompareFilterSame<_Type, _Type>
 {
+	static constexpr bool Equal(const _Type& lhs, const _Type& rhs)
+	{ return lhs == rhs; }
 	static constexpr bool Less(const _Type& lhs, const _Type& rhs)
 	{ return lhs < rhs; }
 	static constexpr bool Greater(const _Type& lhs, const _Type& rhs)
@@ -309,6 +371,11 @@ struct Compare;
 template<typename _LhsType, typename _RhsType>
 struct Compare
 {
+	static constexpr bool Equal(const _LhsType& lhs, const _RhsType& rhs)
+	{
+		return CompareFilterSame<_LhsType, _RhsType>::Equal(lhs, rhs);
+	}
+
 	static constexpr bool Less(const _LhsType& lhs, const _RhsType& rhs)
 	{
 		return CompareFilterSame<_LhsType, _RhsType>::Less(lhs, rhs);
@@ -329,6 +396,13 @@ struct Compare
 		return !Less(lhs, rhs);
 	}
 }; // struct Compare
+
+static_assert(!Compare<uint32_t, int32_t>::Equal(
+	static_cast<uint32_t>(10), static_cast<int32_t>(-10)),
+	"Implementation Error");
+static_assert(Compare<uint32_t, int32_t>::Equal(
+	static_cast<uint32_t>(10), static_cast<int32_t>(10)),
+	"Implementation Error");
 
 static_assert(!(static_cast<uint32_t>(10) > static_cast<int32_t>(-20)),
 	"Implementation Error");

--- a/include/SimpleObjects/PrimitiveCmp.hpp
+++ b/include/SimpleObjects/PrimitiveCmp.hpp
@@ -404,24 +404,24 @@ static_assert(Compare<uint32_t, int32_t>::Equal(
 	static_cast<uint32_t>(10), static_cast<int32_t>(10)),
 	"Implementation Error");
 
-static_assert(!(static_cast<uint32_t>(10) > static_cast<int32_t>(-20)),
-	"Implementation Error");
+// static_assert(!(static_cast<uint32_t>(10) > static_cast<int32_t>(-20)),
+// 	"Implementation Error");
 static_assert(Compare<uint32_t, int32_t>::Greater(
 	static_cast<uint32_t>(10), static_cast<int32_t>(-20)),
 	"Implementation Error");
-static_assert(!(static_cast<int32_t>(-20) < static_cast<uint32_t>(10)),
-	"Implementation Error");
+// static_assert(!(static_cast<int32_t>(-20) < static_cast<uint32_t>(10)),
+// 	"Implementation Error");
 static_assert(Compare<int32_t, uint32_t>::Less(
 	static_cast<int32_t>(-20), static_cast<uint32_t>(10)),
 	"Implementation Error");
 
-static_assert(!(static_cast<uint32_t>(10) >= static_cast<int32_t>(-20)),
-	"Implementation Error");
+// static_assert(!(static_cast<uint32_t>(10) >= static_cast<int32_t>(-20)),
+// 	"Implementation Error");
 static_assert(Compare<uint32_t, int32_t>::GreaterEqual(
 	static_cast<uint32_t>(10), static_cast<int32_t>(-20)),
 	"Implementation Error");
-static_assert(!(static_cast<int32_t>(-20) <= static_cast<uint32_t>(10)),
-	"Implementation Error");
+// static_assert(!(static_cast<int32_t>(-20) <= static_cast<uint32_t>(10)),
+// 	"Implementation Error");
 static_assert(Compare<int32_t, uint32_t>::LessEqual(
 	static_cast<int32_t>(-20), static_cast<uint32_t>(10)),
 	"Implementation Error");

--- a/include/SimpleObjects/PrimitiveCmp.hpp
+++ b/include/SimpleObjects/PrimitiveCmp.hpp
@@ -22,16 +22,26 @@ struct IsPrimitiveType;
 template<typename _T> struct IsPrimitiveType : std::false_type {};
 
 template<> struct IsPrimitiveType<bool    > : std::true_type {};
-template<> struct IsPrimitiveType<int8_t  > : std::true_type {};
-template<> struct IsPrimitiveType<int16_t > : std::true_type {};
-template<> struct IsPrimitiveType<int32_t > : std::true_type {};
-template<> struct IsPrimitiveType<int64_t > : std::true_type {};
-template<> struct IsPrimitiveType<uint8_t > : std::true_type {};
-template<> struct IsPrimitiveType<uint16_t> : std::true_type {};
-template<> struct IsPrimitiveType<uint32_t> : std::true_type {};
-template<> struct IsPrimitiveType<uint64_t> : std::true_type {};
-template<> struct IsPrimitiveType<float   > : std::true_type {};
-template<> struct IsPrimitiveType<double  > : std::true_type {};
+// char
+template<> struct IsPrimitiveType<char         > : std::true_type {};
+template<> struct IsPrimitiveType<signed   char> : std::true_type {};
+template<> struct IsPrimitiveType<unsigned char> : std::true_type {};
+// short
+template<> struct IsPrimitiveType<signed   short> : std::true_type {};
+template<> struct IsPrimitiveType<unsigned short> : std::true_type {};
+// int
+template<> struct IsPrimitiveType<signed   int> : std::true_type {};
+template<> struct IsPrimitiveType<unsigned int> : std::true_type {};
+// long
+template<> struct IsPrimitiveType<signed   long> : std::true_type {};
+template<> struct IsPrimitiveType<unsigned long> : std::true_type {};
+// long long
+template<> struct IsPrimitiveType<signed   long long> : std::true_type {};
+template<> struct IsPrimitiveType<unsigned long long> : std::true_type {};
+// float
+template<> struct IsPrimitiveType<float > : std::true_type {};
+// double
+template<> struct IsPrimitiveType<double> : std::true_type {};
 
 static_assert(IsPrimitiveType<bool    >::value, "Implementation Error");
 static_assert(IsPrimitiveType<int8_t  >::value, "Implementation Error");

--- a/include/SimpleObjects/String.hpp
+++ b/include/SimpleObjects/String.hpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "PrimitiveCmp.hpp"
 #include "ToString.hpp"
 #include "Utils.hpp"
 
@@ -301,9 +302,11 @@ public:
 	virtual bool Equal(size_t pos1, size_t count1,
 		const_pointer begin, const_pointer end) const override
 	{
-		return ((end - begin) != size()) ?
-			false :
-			std::equal(&m_data[pos1], &m_data[pos1 + count1], begin);
+		auto ptrDiff = end - begin;
+		return Internal::Compare<decltype(ptrDiff), size_t>::Equal(
+				ptrDiff, size()) ?
+			std::equal(&m_data[pos1], &m_data[pos1 + count1], begin) :
+			false;
 	}
 
 	// ========== operators ==========

--- a/include/SimpleObjects/Utils.hpp
+++ b/include/SimpleObjects/Utils.hpp
@@ -55,14 +55,14 @@ template<>
 struct IfConstexpr<true>
 {
 	template<typename _TrOpType, typename _FaOpType>
-	static void Eval(_TrOpType tOp, _FaOpType fOp) { tOp(); }
+	static void Eval(_TrOpType tOp, _FaOpType) { tOp(); }
 };
 
 template<>
 struct IfConstexpr<false>
 {
 	template<typename _TrOpType, typename _FaOpType>
-	static void Eval(_TrOpType tOp, _FaOpType fOp) { fOp(); }
+	static void Eval(_TrOpType, _FaOpType fOp) { fOp(); }
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if(MSVC)
 	set(RELEASE_OPTIONS /MT /Ox /Oi /Ob2 /fp:fast)# /DNDEBUG
 else()
 	set(COMMON_OPTIONS -pthread -Wall -Wextra -Werror
-		-pedantic -pedantic-errors)
+		-pedantic -Wpedantic -pedantic-errors)
 	set(DEBUG_OPTIONS -O0 -g -DDEBUG)
 	set(RELEASE_OPTIONS -O2) #-DNDEBUG defined by default
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,12 +13,12 @@ include(TestCoverage.cmake)
 ################################################################################
 
 if(MSVC)
-	set(COMMON_OPTIONS /W3 /wd4996 /we4239 /we4002 /we4700 /we4305 /EHsc /MP
-		/GR /Zc:__cplusplus)
+	set(COMMON_OPTIONS /W4 /WX /EHsc /MP /GR /Zc:__cplusplus)
 	set(DEBUG_OPTIONS /MTd /Od /Zi /DDEBUG)
 	set(RELEASE_OPTIONS /MT /Ox /Oi /Ob2 /fp:fast)# /DNDEBUG
 else()
-	set(COMMON_OPTIONS -pthread)
+	set(COMMON_OPTIONS -pthread -Wall -Wextra -Werror
+		-pedantic -pedantic-errors)
 	set(DEBUG_OPTIONS -O0 -g -DDEBUG)
 	set(RELEASE_OPTIONS -O2) #-DNDEBUG defined by default
 endif()
@@ -56,9 +56,9 @@ file(GLOB_RECURSE SOURCES ${SOURCES_DIR_PATH}/*.[ch]*)
 
 add_executable(SimpleObjects_test ${SOURCES})
 
-target_compile_options(SimpleObjects_test PUBLIC
-	"$<$<CONFIG:Debug>:${DEBUG_OPTIONS}>"
-	"$<$<CONFIG:Release>:${RELEASE_OPTIONS}>")
+target_compile_options(SimpleObjects_test
+	PRIVATE "$<$<CONFIG:Debug>:${DEBUG_OPTIONS}>"
+			"$<$<CONFIG:Release>:${RELEASE_OPTIONS}>")
 target_link_libraries(SimpleObjects_test SimpleObjects gtest)
 
 add_test(NAME SimpleObjects_test

--- a/test/src/TestBaseObjects.cpp
+++ b/test/src/TestBaseObjects.cpp
@@ -21,6 +21,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestBaseObjects, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 // Nothing to be tested on Base object for now

--- a/test/src/TestConstSequence.cpp
+++ b/test/src/TestConstSequence.cpp
@@ -25,6 +25,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestConstSequence, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestConstSequence, ArrayLen)

--- a/test/src/TestD2A.cpp
+++ b/test/src/TestD2A.cpp
@@ -21,6 +21,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestD2A, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestD2A, Zeros) {

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -254,7 +254,8 @@ GTEST_TEST(TestDict, At)
 	};
 	const Dict kCpDc = cpDc;
 
-	EXPECT_EQ(cpDc[Null()], testDc.at(Null()));
+	auto tmpNull = Null();
+	EXPECT_EQ(cpDc[tmpNull], testDc.at(Null()));
 	EXPECT_EQ(cpDc[Int64(1)], testDc.at(Int64(1)));
 
 	EXPECT_EQ(kCpDc[Int64(1)], testDc.at(Int64(1)));

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -25,6 +25,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestDict, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestDict, Construction)

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -64,6 +64,8 @@ GTEST_TEST(TestDict, Assignment)
 	EXPECT_EQ(cpDc.size(), 0);
 	cpDc = testDc;
 	EXPECT_EQ(cpDc, testDc);
+	// We want to ensure assignment self is OK,
+	// meanwhile to avoid compiler warning
 	Dict* cpDcPtr = nullptr;
 	cpDcPtr = &cpDc;
 	cpDc = *cpDcPtr;

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -64,14 +64,18 @@ GTEST_TEST(TestDict, Assignment)
 	EXPECT_EQ(cpDc.size(), 0);
 	cpDc = testDc;
 	EXPECT_EQ(cpDc, testDc);
-	cpDc = cpDc;
+	Dict* cpDcPtr = nullptr;
+	cpDcPtr = &cpDc;
+	cpDc = *cpDcPtr;
 	EXPECT_EQ(cpDc, testDc);
 
 	Dict mvDc;
 	EXPECT_EQ(mvDc.size(), 0);
 	mvDc = std::move(cpDc);
 	EXPECT_EQ(mvDc, testDc);
-	mvDc = std::move(mvDc);
+	Dict* mvDcPtr = nullptr;
+	mvDcPtr = &mvDc;
+	mvDc = std::move(*mvDcPtr);
 	EXPECT_EQ(mvDc, testDc);
 }
 

--- a/test/src/TestHashableObject.cpp
+++ b/test/src/TestHashableObject.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestHashableObj, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestHashableObj, Construction)

--- a/test/src/TestIterator.cpp
+++ b/test/src/TestIterator.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestIterator, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestIterator, ItTraits)

--- a/test/src/TestList.cpp
+++ b/test/src/TestList.cpp
@@ -56,14 +56,20 @@ GTEST_TEST(TestList, Assignment)
 	EXPECT_EQ(cpLs.size(), 0);
 	cpLs = testLs;
 	EXPECT_EQ(cpLs, testLs);
-	cpLs = cpLs;
+	// We want to ensure assignment self is OK,
+	// meanwhile to avoid compiler warning
+	List* cpLsPtr = nullptr;
+	cpLsPtr = &cpLs;
+	cpLs = *cpLsPtr;
 	EXPECT_EQ(cpLs, testLs);
 
 	List mvLs;
 	EXPECT_EQ(mvLs.size(), 0);
 	mvLs = std::move(cpLs);
 	EXPECT_EQ(mvLs, testLs);
-	mvLs = std::move(mvLs);
+	List* mvLsPtr = nullptr;
+	mvLsPtr = &mvLs;
+	mvLs = std::move(*mvLsPtr);
 	EXPECT_EQ(mvLs, testLs);
 }
 

--- a/test/src/TestList.cpp
+++ b/test/src/TestList.cpp
@@ -25,6 +25,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestList, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestList, Construction)

--- a/test/src/TestNull.cpp
+++ b/test/src/TestNull.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestNull, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestNull, Construction)

--- a/test/src/TestNumeric.cpp
+++ b/test/src/TestNumeric.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestNumeric, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestNumeric, Construction)

--- a/test/src/TestNumericTypeInfer.cpp
+++ b/test/src/TestNumericTypeInfer.cpp
@@ -21,6 +21,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestNumericTypeInfer, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestNumericTypeInfer, InferBinOpRetType)

--- a/test/src/TestObject.cpp
+++ b/test/src/TestObject.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestObject, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestObject, Construction)

--- a/test/src/TestStaticDict.cpp
+++ b/test/src/TestStaticDict.cpp
@@ -73,7 +73,7 @@ GTEST_TEST(TestStaticDict, KeyValuePairs)
 	using Key1 = StrKey<SIMOBJ_KSTR("Key1")>;
 	using Key2 = StrKey<SIMOBJ_KSTR("Key2")>;
 	using Key3 = Int64Key<3>;
-	using KeyX = StrKey<SIMOBJ_KSTR("KeyX")>;
+	// using KeyX = StrKey<SIMOBJ_KSTR("KeyX")>;
 
 	using Tp = std::tuple<
 		std::pair<Key1, String>,

--- a/test/src/TestStaticDict.cpp
+++ b/test/src/TestStaticDict.cpp
@@ -25,6 +25,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestStaticDict, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestStaticDict, StaticString)

--- a/test/src/TestStaticDict.cpp
+++ b/test/src/TestStaticDict.cpp
@@ -456,7 +456,11 @@ GTEST_TEST(TestStaticDict, Assignment)
 	EXPECT_EQ(dictCp.get_Key2_1(), String("val2_1"));
 	EXPECT_EQ(dictCp.get_Key2_2(), Int64(12345));
 	EXPECT_EQ(dictCp.get_Key2_3().get_Key1_1(), Int64(54321));
-	dictCp = dictCp; // self copy ==> no op
+	// We want to ensure self assignment is OK,
+	// meanwhile to avoid compiler warning
+	TestStaticDict2* dictCpPtr = nullptr;
+	dictCpPtr = &dictCp;
+	dictCp = *dictCpPtr; // self copy ==> no op
 	EXPECT_EQ(dictCp.get_Key2_1(), String("val2_1"));
 	EXPECT_EQ(dictCp.get_Key2_2(), Int64(12345));
 	EXPECT_EQ(dictCp.get_Key2_3().get_Key1_1(), Int64(54321));
@@ -470,7 +474,9 @@ GTEST_TEST(TestStaticDict, Assignment)
 	EXPECT_EQ(dictMv.get_Key2_1(), String("val2_1"));
 	EXPECT_EQ(dictMv.get_Key2_2(), Int64(12345));
 	EXPECT_EQ(dictMv.get_Key2_3().get_Key1_1(), Int64(54321));
-	dictMv = std::move(dictMv); // self move ==> no op
+	TestStaticDict2* dictMvPtr = nullptr;
+	dictMvPtr = &dictMv;
+	dictMv = std::move(*dictMvPtr); // self move ==> no op
 	EXPECT_EQ(dictMv.get_Key2_1(), String("val2_1"));
 	EXPECT_EQ(dictMv.get_Key2_2(), Int64(12345));
 	EXPECT_EQ(dictMv.get_Key2_3().get_Key1_1(), Int64(54321));

--- a/test/src/TestString.cpp
+++ b/test/src/TestString.cpp
@@ -25,6 +25,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestString, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestString, Construction)

--- a/test/src/TestString.cpp
+++ b/test/src/TestString.cpp
@@ -55,14 +55,20 @@ GTEST_TEST(TestString, Assignment)
 	EXPECT_EQ(cpStr.size(), 0);
 	cpStr = testStr;
 	EXPECT_EQ(cpStr, testStr);
-	cpStr = cpStr;
+	// We want to ensure assignment self is OK,
+	// meanwhile to avoid compiler warning
+	String* cpStrPtr = nullptr;
+	cpStrPtr = &cpStr;
+	cpStr = *cpStrPtr;
 	EXPECT_EQ(cpStr, testStr);
 
 	String mvStr;
 	EXPECT_EQ(mvStr.size(), 0);
 	mvStr = std::move(cpStr);
 	EXPECT_EQ(mvStr, testStr);
-	mvStr = std::move(mvStr);
+	String* mvStrPtr = nullptr;
+	mvStrPtr = &mvStr;
+	mvStr = std::move(*mvStrPtr);
 	EXPECT_EQ(mvStr, testStr);
 }
 

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -23,6 +23,7 @@ namespace SimpleObjects_Test
 GTEST_TEST(TestUtils, CountTestFile)
 {
 	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
 }
 
 GTEST_TEST(TestUtils, BoolToInt)


### PR DESCRIPTION
- Upgraded unit test code warning level
  - On MSVC
    - Upgraded to warning level 4
    - treat all warnings as error
  - On other platforms
    -  enabled `-Wall`, `-Wextra`, and `-pedantic` (also `-Wpedantic`)
    - treat all warnings as error