### PR TITLE
Added endianness header

### DIFF
--- a/include/SimpleObjects/Endianness.hpp
+++ b/include/SimpleObjects/Endianness.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Haofan Zheng
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <version>
+#ifdef __cpp_lib_endian
+#include <bit>
+#endif
+
+
+#ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+namespace SimpleObjects
+#else
+namespace SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+#endif
+{
+
+enum class Endian
+{
+#ifdef __cpp_lib_endian
+    little =
+		static_cast<std::underlying_type_t<std::endian> >(std::endian::little),
+    big    =
+		static_cast<std::underlying_type_t<std::endian> >(std::endian::big),
+    native =
+		static_cast<std::underlying_type_t<std::endian> >(std::endian::native),
+// src: https://en.cppreference.com/w/cpp/types/endian
+#elif defined(_WIN32)
+    little = 0,
+    big    = 1,
+    native = little,
+#elif defined(__ORDER_LITTLE_ENDIAN__) && \
+		defined(__ORDER_BIG_ENDIAN__) && \
+		defined(__BYTE_ORDER__)
+    little = __ORDER_LITTLE_ENDIAN__,
+    big    = __ORDER_BIG_ENDIAN__,
+    native = __BYTE_ORDER__,
+#else
+#	error "Cannot determine the platform endianness"
+#endif
+}; // enum class Endian
+
+} // namespace SimpleObjects

--- a/test/src/Main.cpp
+++ b/test/src/Main.cpp
@@ -12,7 +12,7 @@ namespace SimpleObjects_Test
 
 int main(int argc, char** argv)
 {
-	constexpr size_t EXPECTED_NUM_OF_TEST_FILE = 15;
+	constexpr size_t EXPECTED_NUM_OF_TEST_FILE = 16;
 
 	std::cout << "===== SimpleObjects test program =====" << std::endl;
 	std::cout << std::endl;

--- a/test/src/TestEndianness.cpp
+++ b/test/src/TestEndianness.cpp
@@ -1,0 +1,33 @@
+// Copyright 2022 Haofan Zheng
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <gtest/gtest.h>
+
+#include <SimpleObjects/Endianness.hpp>
+
+#ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
+using namespace SimpleObjects;
+#else
+using namespace SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE;
+#endif
+
+namespace SimpleObjects_Test
+{
+	extern size_t g_numOfTestFile;
+}
+
+GTEST_TEST(TestEndianness, CountTestFile)
+{
+	static auto tmp = ++SimpleObjects_Test::g_numOfTestFile;
+	(void)tmp;
+}
+
+GTEST_TEST(TestEndianness, Endianness)
+{
+	EXPECT_TRUE(
+		(Endian::native == Endian::little) ||
+		(Endian::native == Endian::big)
+	);
+}


### PR DESCRIPTION
This header was part of the SimpleRlp project, but it becomes useful in other projects too, thus, it has been moved to this project since many other projects already rely on the Exception class of this project.