### PR TITLE
Bug fixes and new bytes to hex func

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-22.04, windows-latest, macos-latest ]
         std: [ 11, 20 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/include/SimpleObjects/BaseObject.hpp
+++ b/include/SimpleObjects/BaseObject.hpp
@@ -184,6 +184,7 @@ public:
 
 	// TODO:
 	// =
+	Self& operator=(const Self& rhs) = delete;
 	// +=
 	// +
 	// slice

--- a/include/SimpleObjects/Bytes.hpp
+++ b/include/SimpleObjects/Bytes.hpp
@@ -403,7 +403,10 @@ private:
 
 		for (const auto& b : m_data)
 		{
-			Internal::ByteToString<_CharType>(outit, static_cast<uint8_t>(b));
+			Internal::ByteToHEX<true, _CharType>(
+				outit,
+				static_cast<uint8_t>(b)
+			);
 		}
 
 		*outit++ = '\"';

--- a/include/SimpleObjects/Null.hpp
+++ b/include/SimpleObjects/Null.hpp
@@ -134,6 +134,12 @@ public:
 	bool operator<=(const Self& rhs) const = delete;
 	bool operator>=(const Self& rhs) const = delete;
 
+	Self& operator=(const Self&)
+	{
+		// nothing to copy from
+		return *this;
+	}
+
 	// ===== BaseObject class
 
 	virtual bool BaseObjectIsEqual(const BaseBase& rhs) const override

--- a/include/SimpleObjects/ToString.hpp
+++ b/include/SimpleObjects/ToString.hpp
@@ -38,13 +38,20 @@ inline _OutputType ToString(_ItType begin, _ItType end)
 	return _OutputType(begin, end);
 }
 
-template<typename _CharType, typename _OutIt>
-inline void ByteToString(_OutIt destIt, uint8_t b)
+template<bool _Prefix, typename _CharType, typename _OutIt>
+inline void ByteToHEX(_OutIt destIt, uint8_t b)
 {
 	static constexpr char alphabet[] = "0123456789ABCDEF";
 
-	*destIt++ = static_cast<_CharType>('\\');
-	*destIt++ = static_cast<_CharType>('x');
+	if
+#if __cplusplus >= 201703L
+		constexpr
+#endif
+	(_Prefix)
+	{
+		*destIt++ = static_cast<_CharType>('\\');
+		*destIt++ = static_cast<_CharType>('x');
+	}
 
 	// the first nibble (half of byte)
 	*destIt++ = static_cast<_CharType>(
@@ -53,6 +60,30 @@ inline void ByteToString(_OutIt destIt, uint8_t b)
 	// the second nibble (half of byte)
 	*destIt++ = static_cast<_CharType>(
 		alphabet[(b & 0x0F)]);
+}
+
+template<
+	bool _Prefix,
+	typename _CharType,
+	typename _OutIt,
+	typename _InIt
+>
+inline void BytesToHEX(_OutIt destIt, _InIt begin, _InIt end)
+{
+	if
+#if __cplusplus >= 201703L
+		constexpr
+#endif
+	(_Prefix)
+	{
+		*destIt++ = static_cast<_CharType>('0');
+		*destIt++ = static_cast<_CharType>('x');
+	}
+
+	for (; begin != end; ++begin)
+	{
+		ByteToHEX<false, _CharType, _OutIt>(destIt, *begin);
+	}
 }
 
 } // Internal

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -277,6 +277,50 @@ GTEST_TEST(TestDict, At)
 	EXPECT_TRUE(cpDc[String("3")].IsNull());
 }
 
+GTEST_TEST(TestDict, SubscriptAssign)
+{
+	// Dict
+	{
+		auto dict = Dict();
+		dict[String("test")] = String("test val");
+
+		auto it = dict.cbegin();
+		ASSERT_NE(
+			&(it->first.GetVal()),
+			nullptr
+		);
+		EXPECT_EQ(
+			it->first.GetVal(),
+			String("test")
+		);
+		EXPECT_EQ(
+			it->second,
+			String("test val")
+		);
+	}
+
+	// DictBase
+	{
+		auto dictObj = Dict();
+		DictBaseObj& dict = dictObj;
+		dict[String("test")]; // TODO: assign value when this is supported = String("test val");
+
+		auto it = dict.cbegin();
+		ASSERT_NE(
+			&(*std::get<0>(*it)),
+			nullptr
+		);
+		EXPECT_EQ(
+			*std::get<0>(*it),
+			String("test")
+		);
+		EXPECT_EQ(
+			*std::get<1>(*it),
+			Null()
+		);
+	}
+}
+
 GTEST_TEST(TestDict, FindKey)
 {
 	Dict cpDc = {

--- a/test/src/TestDict.cpp
+++ b/test/src/TestDict.cpp
@@ -290,12 +290,12 @@ GTEST_TEST(TestDict, SubscriptAssign)
 			nullptr
 		);
 		EXPECT_EQ(
-			it->first.GetVal(),
-			String("test")
+			it->first.GetVal().AsString(),
+			String("test").AsString()
 		);
 		EXPECT_EQ(
-			it->second,
-			String("test val")
+			it->second.AsString(),
+			String("test val").AsString()
 		);
 	}
 

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <SimpleObjects/Utils.hpp>
+#include <SimpleObjects/ToString.hpp>
 
 #ifndef SIMPLEOBJECTS_CUSTOMIZED_NAMESPACE
 using namespace SimpleObjects;
@@ -59,4 +60,58 @@ GTEST_TEST(TestUtils, IfConstexpr)
 		[]() { EXPECT_TRUE(false); },
 		[]() { EXPECT_TRUE(true); } // This one should always run
 	);
+}
+
+GTEST_TEST(TestUtils, ByteToHEX)
+{
+	{
+		std::string expOut = "\\x7F";
+		std::string testOut;
+
+		Internal::ByteToHEX<true, char>(std::back_inserter(testOut), 0x7FU);
+
+		EXPECT_EQ(testOut, expOut);
+	}
+
+	{
+		std::string expOut = "F5";
+		std::string testOut;
+
+		Internal::ByteToHEX<false, char>(std::back_inserter(testOut), 0xF5U);
+
+		EXPECT_EQ(testOut, expOut);
+	}
+}
+
+GTEST_TEST(TestUtils, BytesToHEX)
+{
+	{
+		std::vector<uint8_t> testIn =
+			{ 0x00U, 0x01U, 0x02U, 0x03U, 0x04U, 0x05U, };
+		std::string expOut = "0x000102030405";
+		std::string testOut;
+
+		Internal::BytesToHEX<true, char>(
+			std::back_inserter(testOut),
+			testIn.begin(),
+			testIn.end()
+		);
+
+		EXPECT_EQ(testOut, expOut);
+	}
+
+	{
+		std::vector<uint8_t> testIn =
+			{ 0x45U, 0x67U, 0x89U, 0xABU, 0xCDU, 0xEFU, };
+		std::string expOut = "456789ABCDEF";
+		std::string testOut;
+
+		Internal::BytesToHEX<false, char>(
+			std::back_inserter(testOut),
+			testIn.begin(),
+			testIn.end()
+		);
+
+		EXPECT_EQ(testOut, expOut);
+	}
 }


### PR DESCRIPTION
- Fixed the bug that causes `nullptr` when assigning new key-value pair to Dict using `[ ]` operator
- Added function to convert bytes to hex